### PR TITLE
Add support to new logLevel field for probe exporter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Current Operator version
-VERSION ?= 0.3.1
+VERSION ?= 0.3.2
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/3scale/prometheus-exporter-operator:v$(VERSION)
 # Default catalog image

--- a/bundle/manifests/monitoring.3scale.net_prometheusexporters.yaml
+++ b/bundle/manifests/monitoring.3scale.net_prometheusexporters.yaml
@@ -32,7 +32,7 @@ spec:
                 description: For cloudwatch exporter, the Secret name containing AWS IAM credentials (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY)
                 type: string
               configurationConfigmapName:
-                description: For cloudwatch exporter, the ConfigMap name containing Cloudwatch config.yml (Services, Dimensions, Tags used for autodiscovery...)
+                description: For cloudwatch exporter, the ConfigMap name containing Cloudwatch config.yml (Services, Dimensions, Tags used for autodiscovery...). For probe exporter, ConfigMap name containing blackbox modules configuration.
                 type: string
               dbCheckKeys:
                 description: For redis exporter, the optional redis keys to monitor
@@ -99,6 +99,12 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              logLevel:
+                description: For probe exporter, log level of the exporter
+                enum:
+                - info
+                - debug
+                type: string
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/bundle/manifests/prometheus-exporter-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/prometheus-exporter-operator.clusterserviceversion.yaml
@@ -33,7 +33,7 @@ metadata:
     operators.operatorframework.io/project_layout: ansible.sdk.operatorframework.io/v1
     repository: https://github.com/3scale-ops/prometheus-exporter-operator
     support: Red Hat, Inc.
-  name: prometheus-exporter-operator.v0.3.1
+  name: prometheus-exporter-operator.v0.3.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -113,7 +113,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/prometheus-exporter-operator:v0.3.1
+                image: quay.io/3scale/prometheus-exporter-operator:v0.3.2
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -270,4 +270,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.redhat.com
-  version: 0.3.1
+  version: 0.3.2

--- a/config/crd/bases/monitoring.3scale.net_prometheusexporters.yaml
+++ b/config/crd/bases/monitoring.3scale.net_prometheusexporters.yaml
@@ -172,7 +172,7 @@ spec:
                 description: For redis, memcached, sphinx and es exporters, the db port to monitor
               dbCheckKeys:
                 type: string
-                description: 'For redis exporter, the optional redis keys to monitor'
+                description: For redis exporter, the optional redis keys to monitor
               dbConnectionStringSecretName:
                 type: string
                 description: For mysql and postgresql exporters, the Secret name containing connection string definition (DSN)
@@ -181,7 +181,13 @@ spec:
                 description: For cloudwatch exporter, the Secret name containing AWS IAM credentials (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY)
               configurationConfigmapName:
                 type: string
-                description: For cloudwatch exporter, the ConfigMap name containing Cloudwatch config.yml (Services, Dimensions, Tags used for autodiscovery...)
+                description: For cloudwatch exporter, the ConfigMap name containing Cloudwatch config.yml (Services, Dimensions, Tags used for autodiscovery...). For probe exporter, ConfigMap name containing blackbox modules configuration.
+              logLevel:
+                type: string
+                description: For probe exporter, log level of the exporter
+                enum:
+                - info
+                - debug
             type: object
             required:
             - type

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/prometheus-exporter-operator
-  newTag: v0.3.1
+  newTag: v0.3.2

--- a/docs/prometheus-exporter-crd-reference.md
+++ b/docs/prometheus-exporter-crd-reference.md
@@ -157,6 +157,7 @@ Specific CR fields per exporter type:
 | **Field** | **Type** | **Required** | **Default value** | **Description** |
 |:---:|:---:|:---:|:---:|:---:|
 | `configurationConfigmapName` | `string` | Yes | `prometheus-exporter-probe-${CR_NAME}` | ConfigMap name containing blackbox modules configuration `config.yml` (http_2xx, tcp_connect...) |
+| `logLevel` | `string` | No | `debug` | Log level of the exporter (debug/info) |
 
 * Image, port, resources, liveness, readiness default values can be found at [ansible-probe-vars](../roles/prometheusexporter/exporters/probe/vars.yml)
 * Real `probe` example can be found on [examples](../examples/README.md#probe) directory.

--- a/roles/prometheusexporter/exporters/probe/container.yml.j2
+++ b/roles/prometheusexporter/exporters/probe/container.yml.j2
@@ -1,6 +1,6 @@
 args:
   - --config.file=/etc/blackbox_exporter/config.yml
-  - --log.level=debug
+  - --log.level={{ log_level }}
 volumeMounts:
   - mountPath: /etc/blackbox_exporter
     name: config-volume

--- a/roles/prometheusexporter/exporters/probe/vars.yml
+++ b/roles/prometheusexporter/exporters/probe/vars.yml
@@ -19,6 +19,7 @@ resources_limits_memory: "64Mi"
 
 # Custom
 configuration_configmap_name: "prometheus-exporter-{{ type }}-{{ ansible_operator_meta.name }}"
+log_level: "debug"
 
 ###### Example of ConfigMap
 #


### PR DESCRIPTION
Closes https://github.com/3scale-ops/prometheus-exporter-operator/issues/27

Adds supports to setup `logLevel` on probe (blackbox) exporter (in the future this CRD field could be used for other exporters), current supported values are `debug` (default one) and `info`, and it is validated through CRD

It has been successfully tested, even an operator olm upgrade, with alpha release `v0.3.2-alpha.2`

Once merged into `main` branch it will be created a new stable release `v0.3.2`, and we will upgrade operator-hub version (currently it is published old `v0.2.4`, prior to major `v1`operator-sdk upgrade, which included the new olm bundle-format, new CRD api, new naming for operator deployment, role...)

/kind feature
/priority important-soon
/assign