### PR TITLE
Feat/Add support to probe-exporter to use optionally a Secret for blackbox modules config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Current Operator version
-VERSION ?= 0.3.2
+VERSION ?= 0.3.3
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/3scale/prometheus-exporter-operator:v$(VERSION)
 # Default catalog image

--- a/bundle/manifests/monitoring.3scale.net_prometheusexporters.yaml
+++ b/bundle/manifests/monitoring.3scale.net_prometheusexporters.yaml
@@ -34,6 +34,9 @@ spec:
               configurationConfigmapName:
                 description: For cloudwatch exporter, the ConfigMap name containing Cloudwatch config.yml (Services, Dimensions, Tags used for autodiscovery...). For probe exporter, ConfigMap name containing blackbox modules configuration.
                 type: string
+              configurationSecretName:
+                description: For probe exporter, optional Secret name containing blackbox modules configuration. Replaces usage of configurationConfigmapName (in case config includes sensitive data and so you prefer to use a Secret)
+                type: string
               dbCheckKeys:
                 description: For redis exporter, the optional redis keys to monitor
                 type: string

--- a/bundle/manifests/prometheus-exporter-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/prometheus-exporter-operator.clusterserviceversion.yaml
@@ -33,7 +33,7 @@ metadata:
     operators.operatorframework.io/project_layout: ansible.sdk.operatorframework.io/v1
     repository: https://github.com/3scale-ops/prometheus-exporter-operator
     support: Red Hat, Inc.
-  name: prometheus-exporter-operator.v0.3.2
+  name: prometheus-exporter-operator.v0.3.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -113,7 +113,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/prometheus-exporter-operator:v0.3.2
+                image: quay.io/3scale/prometheus-exporter-operator:v0.3.3
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -270,4 +270,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.redhat.com
-  version: 0.3.2
+  version: 0.3.3

--- a/config/crd/bases/monitoring.3scale.net_prometheusexporters.yaml
+++ b/config/crd/bases/monitoring.3scale.net_prometheusexporters.yaml
@@ -182,6 +182,9 @@ spec:
               configurationConfigmapName:
                 type: string
                 description: For cloudwatch exporter, the ConfigMap name containing Cloudwatch config.yml (Services, Dimensions, Tags used for autodiscovery...). For probe exporter, ConfigMap name containing blackbox modules configuration.
+              configurationSecretName:
+                description: For probe exporter, optional Secret name containing blackbox modules configuration. Replaces usage of configurationConfigmapName (in case config includes sensitive data and so you prefer to use a Secret)
+                type: string
               logLevel:
                 type: string
                 description: For probe exporter, log level of the exporter

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/prometheus-exporter-operator
-  newTag: v0.3.2
+  newTag: v0.3.3

--- a/docs/prometheus-exporter-crd-reference.md
+++ b/docs/prometheus-exporter-crd-reference.md
@@ -157,6 +157,7 @@ Specific CR fields per exporter type:
 | **Field** | **Type** | **Required** | **Default value** | **Description** |
 |:---:|:---:|:---:|:---:|:---:|
 | `configurationConfigmapName` | `string` | Yes | `prometheus-exporter-probe-${CR_NAME}` | ConfigMap name containing blackbox modules configuration `config.yml` (http_2xx, tcp_connect...) |
+| `configurationSecretName` | `string` | No | - | Optional Secret name containing blackbox modules configuration `config.yml` (http_2xx, tcp_connect...). Replaces usage of `configurationConfigmapName` (in case config includes sensitive data and so you prefer to use a Secret) |
 | `logLevel` | `string` | No | `debug` | Log level of the exporter (debug/info) |
 
 * Image, port, resources, liveness, readiness default values can be found at [ansible-probe-vars](../roles/prometheusexporter/exporters/probe/vars.yml)

--- a/examples/README.md
+++ b/examples/README.md
@@ -193,9 +193,11 @@ $ make cloudwatch-delete
 
 * **The ConfigMap should have been previously created as the operator expects it**:
   * **[probe-configmap-example](probe/probe-configmap.yaml) (Remember to set the object name on the CR field `configurationConfigmapName`)**
+* **The optional Secret (replacing previous ConfigMap) should have been previously created as the operator expects it (in case config includes sensitive data and so you prefer to use a Secret**
+  * **[probe-secret-example](probe/probe-secret.yaml) (Remember to set the object name on the CR field `configurationSecretName` replacing previous `configurationConfigmapName`)**
 
 > **NOTE**
-><br /> To deploy a probe exporter (blackbox exporter) it is just needed the configmap with blackbox modules configuration, and a single `PrometheusExporter` custom resource of type `probe`. But then, in order to be able to scrape different targets, you need to deploy for every endpoint that you want to monitor, a prometheus `ServiceMonitor` resource with the `selector.matchLabels` pointing to the deployed probe exporter `app: prometheus-exporter-probe-${CR_NAME}`, and then configure the specific module and target, with a proper relabeling of source label `__param_target` into target label `target` (which is used in the deployed grafana dashboard and possible prometheus alerts).
+><br /> To deploy a probe exporter (blackbox exporter) it is just needed the configmap (or secret) with blackbox modules configuration, and a single `PrometheusExporter` custom resource of type `probe`. But then, in order to be able to scrape different targets, you need to deploy for every endpoint that you want to monitor, a prometheus `ServiceMonitor` resource with the `selector.matchLabels` pointing to the deployed probe exporter `app: prometheus-exporter-probe-${CR_NAME}`, and then configure the specific module and target, with a proper relabeling of source label `__param_target` into target label `target` (which is used in the deployed grafana dashboard and possible prometheus alerts).
 
 ### Target ServiceMonitor extra objects
   * **[probe-target-service-monitor-example](probe/probe-target-service-monitor.yaml) (Remember to set the `selector.matchLabels` pointing to the deployed probe exporter `app: prometheus-exporter-probe-${CR_NAME}`)**

--- a/examples/probe/probe-secret.yaml
+++ b/examples/probe/probe-secret.yaml
@@ -1,0 +1,25 @@
+# In case you don't want to use a Configmap for the blackbox modules config.yml because it might contain sensitive data like keys...
+# you can use a Secret instead, and so specify the Secret name on CR field configurationSecretName (instead of using configurationConfigmapName)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prometheus-exporter-probe-staging-blackbox
+stringData:
+  config.yml: |
+    modules:
+      http_2xx:
+        prober: http
+        timeout: 5s
+        http:
+          method: GET
+          no_follow_redirects: false
+          fail_if_ssl: false
+          fail_if_not_ssl: false
+          tls_config:
+            insecure_skip_verify: false
+          preferred_ip_protocol: "ip4" # defaults to "ip6"
+          ip_protocol_fallback: false  # no fallback to "ip6"
+      tcp_connect:
+        prober: tcp
+        timeout: 5s

--- a/roles/prometheusexporter/exporters/probe/volumes.yml.j2
+++ b/roles/prometheusexporter/exporters/probe/volumes.yml.j2
@@ -1,7 +1,12 @@
 volumes:
   - name: config-volume
+{% if configuration_secret_name is defined %}
+    secret:
+      secretName: "{{ configuration_secret_name }}"
+{% else %}
     configMap:
       name: "{{ configuration_configmap_name }}"
+{% endif %}
       items:
         - key: config.yml
           path: config.yml


### PR DESCRIPTION
By default, probe-exporter (AKA blackbox-exporter) has the modules configuration file defined on a `Configmap` for simplicity.

However, due to the fact that you might consider creation custom modules config with sensitive data like keys, auth, passwords... , this PR adds the possibility to use a `Secret` instead of a `Configmap` (so you can manage that sensitive data on a `Secret` using your favorite secrets-management gitops tool, committing it to a GitHub repository without security concerns).

/kind feature
/priority important-soon
/assign