### PR TITLE
Feat/Improvements on AWS Cloudwatch Elasticsearch monitoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Current Operator version
-VERSION ?= 0.3.3
+VERSION ?= 0.3.4
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/3scale/prometheus-exporter-operator:v$(VERSION)
 # Default catalog image

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,9 +7,9 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=prometheus-exporter-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha,stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
+LABEL operators.operatorframework.io.metrics.project_layout=ansible.sdk.operatorframework.io/v1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.4.0+git
-LABEL operators.operatorframework.io.metrics.project_layout=ansible.sdk.operatorframework.io/v1
 
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1

--- a/bundle/manifests/prometheus-exporter-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/prometheus-exporter-operator.clusterserviceversion.yaml
@@ -33,7 +33,7 @@ metadata:
     operators.operatorframework.io/project_layout: ansible.sdk.operatorframework.io/v1
     repository: https://github.com/3scale-ops/prometheus-exporter-operator
     support: Red Hat, Inc.
-  name: prometheus-exporter-operator.v0.3.3
+  name: prometheus-exporter-operator.v0.3.4
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -113,7 +113,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/prometheus-exporter-operator:v0.3.3
+                image: quay.io/3scale/prometheus-exporter-operator:v0.3.4
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -270,4 +270,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.redhat.com
-  version: 0.3.3
+  version: 0.3.4

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,9 +6,9 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: prometheus-exporter-operator
   operators.operatorframework.io.bundle.channels.v1: alpha,stable
   operators.operatorframework.io.bundle.channel.default.v1: alpha
+  operators.operatorframework.io.metrics.project_layout: ansible.sdk.operatorframework.io/v1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.4.0+git
-  operators.operatorframework.io.metrics.project_layout: ansible.sdk.operatorframework.io/v1
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/prometheus-exporter-operator
-  newTag: v0.3.3
+  newTag: v0.3.4

--- a/examples/cloudwatch/cloudwatch-configmap.yaml
+++ b/examples/cloudwatch/cloudwatch-configmap.yaml
@@ -80,6 +80,10 @@ data:
        aws_statistics: [Maximum]
      - aws_namespace: AWS/ES
        aws_metric_name: FreeStorageSpace
+       aws_dimensions: [DomainName, ClientId]
+       aws_statistics: [Sum]
+     - aws_namespace: AWS/ES
+       aws_metric_name: FreeStorageSpace
        aws_dimensions: [DomainName, ClientId, NodeId]
        aws_statistics: [Minimum]
      - aws_namespace: AWS/ES

--- a/prometheus-rules/cloudwatch-prometheusrule.yaml
+++ b/prometheus-rules/cloudwatch-prometheusrule.yaml
@@ -13,7 +13,7 @@ spec:
           severity: critical
         annotations:
           message: "AWS ElastiCache instance {{ $labels.cache_cluster_id }} from {{ $labels.prometheus_exporter }} has High CPU usage (%)"
-      - alert: AWSElastiCacheFreeableMemoryLow 
+      - alert: AWSElastiCacheFreeableMemoryLow
         expr: aws_elasticache_freeable_memory_average < 1000000000
         for: 2m
         labels:
@@ -69,6 +69,27 @@ spec:
           severity: critical
         annotations:
           message: "AWS Elasticsearch {{ $labels.domain_name }} from {{ $labels.prometheus_exporter }} cluster status is Red"
+      - alert: AWSElasticsearchAutomaticSnapshotFailed
+        expr: aws_es_automated_snapshot_failure_maximum == 1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          message: "AWS Elasticsearch {{ $labels.domain_name }} from {{ $labels.prometheus_exporter }} has failed its automated snapshot"
+      - alert: AWSElasticsearchFreeSpaceDataTotalLow
+        expr: aws_es_free_storage_space_sum < 1000000
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          message: "AWS Elasticsearch {{ $labels.domain_name }} from {{ $labels.prometheus_exporter }} has Low Data Total Free Storage Space (megabytes)"
+      - alert: AWSElasticsearchFreeSpaceDataNodeLow
+        expr: aws_es_free_storage_space_minimum < 100000
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          message: "AWS Elasticsearch {{ $labels.domain_name }} from {{ $labels.prometheus_exporter }} has Low Data Node Free Storage Space (megabytes)"
       - alert: AWSClientVPNCrlDaysToExpiry
         expr: max_over_time(aws_clientvpn_crl_days_to_expiry_average[10m]) < 2
         for: 5m

--- a/roles/prometheusexporter/exporters/cloudwatch/grafanadashboard.json.j2
+++ b/roles/prometheusexporter/exporters/cloudwatch/grafanadashboard.json.j2
@@ -3747,13 +3747,20 @@
               "intervalFactor": 1,
               "legendFormat": "{{ '{{' }} domain_name {{ '}}' }}-master-{{ '{{' }} node_id {{ '}}' }}",
               "refId": "B"
+            },
+            {
+              "expr": "aws_es_free_storage_space_sum{namespace=\"$namespace\", prometheus_exporter=\"$prometheus_exporter\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{ '{{' }} domain_name {{ '}}' }}-data-total",
+              "refId": "B"
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Free Storage Space Minimum (megabytes)",
+          "title": "Free Storage Space Minimum/Sum (megabytes)",
           "tooltip": {
             "shared": true,
             "sort": 2,

--- a/roles/prometheusexporter/exporters/cloudwatch/grafanadashboard.json.j2
+++ b/roles/prometheusexporter/exporters/cloudwatch/grafanadashboard.json.j2
@@ -3761,7 +3761,7 @@
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{ '{{' }} domain_name {{ '}}' }}-data-total",
-              "refId": "B"
+              "refId": "C"
             }
           ],
           "thresholds": [],

--- a/roles/prometheusexporter/exporters/cloudwatch/grafanadashboard.json.j2
+++ b/roles/prometheusexporter/exporters/cloudwatch/grafanadashboard.json.j2
@@ -3435,6 +3435,8 @@
             {
               "expr": "aws_es_cluster_status_green_maximum{namespace=\"$namespace\", prometheus_exporter=\"$prometheus_exporter\"}",
               "format": "time_series",
+              "instant": true,
+              "interval": "",
               "intervalFactor": 1,
               "legendFormat": "{{ '{{' }} domain_name {{ '}}' }}",
               "refId": "A"
@@ -3490,6 +3492,8 @@
             {
               "expr": "aws_es_cluster_status_yellow_maximum{namespace=\"$namespace\", prometheus_exporter=\"$prometheus_exporter\"}",
               "format": "time_series",
+              "instant": true,
+              "interval": "",
               "intervalFactor": 1,
               "legendFormat": "{{ '{{' }} domain_name {{ '}}' }}",
               "refId": "A"
@@ -3545,6 +3549,8 @@
             {
               "expr": "aws_es_cluster_status_red_maximum{namespace=\"$namespace\", prometheus_exporter=\"$prometheus_exporter\"}",
               "format": "time_series",
+              "instant": true,
+              "interval": "",
               "intervalFactor": 1,
               "legendFormat": "{{ '{{' }} domain_name {{ '}}' }}",
               "refId": "A"
@@ -3600,6 +3606,8 @@
             {
               "expr": "aws_es_automated_snapshot_failure_maximum{namespace=\"$namespace\", prometheus_exporter=\"$prometheus_exporter\"}",
               "format": "time_series",
+              "instant": true,
+              "interval": "",
               "intervalFactor": 1,
               "legendFormat": "{{ '{{' }} domain_name {{ '}}' }}",
               "refId": "A"


### PR DESCRIPTION
- Adds AWS CW ES FreeStorage Sum metric (example configuration configmap and grafana dashboard). A part from having individual node free space, it is good the overall free space (sometimes nodes gets unbalanced, this metric helps to  detect it)
- Update  AWS CW ES grafana SingleStats panels to show `instant` value (so last one), it is more efficient in terms of promql performance, and in case of multiple values because pods have been recreated so multiple timeseries with the same metric, it just shows last one. **It is possible that this change will be aplied to all dashboards SingleStats in future PRs** (avoids the error "Multiple timeseries only can be shown one" (or something like that), when pod is recreated.
- Adds more examples of AWS CW ElasticSearch alerts (prometheus rules)
- Operator Release v0.3.4


End to end ests are not passing on GitHub action, there is a problem creating the kind cluster on GitHub Action CI, giving a timeout after 5minutes:
```
 • Waiting ≤ 5m0s for control-plane = Ready ⏳  ...
 ✗ Waiting ≤ 5m0s for control-plane = Ready ⏳
 • WARNING: Timed out waiting for Ready ⚠️
 ```
 
Something similar happens on marin3r repo https://github.com/3scale-ops/marin3r, since a few weeks ago tests are nor passing due to a problem between kind and GH action.
 
Testing locally, e2e tests woks:
```
$ make test-e2e
/home/slopez/work/es-prom-exporter/prometheus-exporter-operator/bin/kind-v0.10.0 create cluster --wait 5m
Creating cluster "kind" ...
 ✓ Ensuring node image (kindest/node:v1.20.2) 🖼
 ✓ Preparing nodes 📦  
 ✓ Writing configuration 📜 
 ✓ Starting control-plane 🕹️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
 ✓ Waiting ≤ 5m0s for control-plane = Ready ⏳ 
 • Ready after 55s 💚
Set kubectl context to "kind-kind"
You can now use your cluster with:

kubectl cluster-info --context kind-kind

Thanks for using kind! 😊
docker build -t quay.io/3scale/prometheus-exporter-operator:v0.3.4 .
Sending build context to Docker daemon 129.6 MB
Step 1/6 : FROM quay.io/operator-framework/ansible-operator:v1.5.0
 ---> 5d900455b2e5
Step 2/6 : COPY requirements.yml ${HOME}/requirements.yml
 ---> Using cache
 ---> ee9eaba506f6
Step 3/6 : RUN ansible-galaxy collection install -r ${HOME}/requirements.yml  && chmod -R ug+rwx ${HOME}/.ansible
 ---> Using cache
 ---> c432f94978b3
Step 4/6 : COPY watches.yaml ${HOME}/watches.yaml
 ---> Using cache
 ---> 1f9c8ccaead2
Step 5/6 : COPY roles/ ${HOME}/roles/
 ---> c0eb588f7144
Removing intermediate container 56fb144d3f48
Step 6/6 : COPY playbooks/ ${HOME}/playbooks/
 ---> d9aec8c94fd9
Removing intermediate container 7ef4adcaae10
Successfully built d9aec8c94fd9
/home/slopez/work/es-prom-exporter/prometheus-exporter-operator/bin/kind-v0.10.0 load docker-image quay.io/3scale/prometheus-exporter-operator:v0.3.4
Image: "quay.io/3scale/prometheus-exporter-operator:v0.3.4" with ID "sha256:d9aec8c94fd987b5ade95eb078a4c90cb5f9e6dc32d1d51d8091f59201bcee0c" not yet present on node "kind-control-plane", loading...
cd config/manager && /home/slopez/bin/kustomize edit set image controller=quay.io/3scale/prometheus-exporter-operator:v0.3.4
/home/slopez/bin/kustomize build config/testing | kubectl apply -f -
namespace/prometheus-exporter-operator-system created
customresourcedefinition.apiextensions.k8s.io/prometheusexporters.monitoring.3scale.net created
customresourcedefinition.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com created
customresourcedefinition.apiextensions.k8s.io/grafanadashboards.integreatly.org created
serviceaccount/prometheus-exporter-operator-controller-manager created
role.rbac.authorization.k8s.io/prometheus-exporter-operator-leader-election-role created
role.rbac.authorization.k8s.io/prometheus-exporter-operator-manager-role created
rolebinding.rbac.authorization.k8s.io/prometheus-exporter-operator-leader-election-rolebinding created
rolebinding.rbac.authorization.k8s.io/prometheus-exporter-operator-manager-rolebinding created
service/prometheus-exporter-operator-controller-manager-metrics-service created
deployment.apps/prometheus-exporter-operator-controller-manager created
mkdir -p /home/slopez/work/es-prom-exporter/prometheus-exporter-operator/bin
curl -sL -o /home/slopez/work/es-prom-exporter/prometheus-exporter-operator/bin/kuttl-v0.9.0 https://github.com/kudobuilder/kuttl/releases/download/v0.9.0/kubectl-kuttl_0.9.0_linux_x86_64
chmod +x /home/slopez/work/es-prom-exporter/prometheus-exporter-operator/bin/kuttl-v0.9.0
/home/slopez/work/es-prom-exporter/prometheus-exporter-operator/bin/kuttl-v0.9.0 test
=== RUN   kuttl
    harness.go:457: starting setup
    harness.go:248: running tests using configured kubeconfig.
    harness.go:285: Successful connection to cluster at: https://127.0.0.1:40277
    harness.go:353: running tests
    harness.go:74: going to run test suite with timeout of 120 seconds for each step
    harness.go:365: testsuite: ./test/e2e/ has 2 tests
=== RUN   kuttl/harness
=== RUN   kuttl/harness/operator
=== PAUSE kuttl/harness/operator
=== RUN   kuttl/harness/prometheusexporter
=== PAUSE kuttl/harness/prometheusexporter
=== CONT  kuttl/harness/operator
    logger.go:42: 14:22:54 | operator | Creating namespace: kuttl-test-assuring-redfish
=== CONT  kuttl/harness/prometheusexporter
    logger.go:42: 14:22:54 | prometheusexporter | Creating namespace: kuttl-test-fit-ant
=== CONT  kuttl/harness/operator
    logger.go:42: 14:22:54 | operator/0- | starting test step 0-
=== CONT  kuttl/harness/prometheusexporter
    logger.go:42: 14:22:54 | prometheusexporter/1-prometheusexporter | starting test step 1-prometheusexporter
=== CONT  kuttl/harness/operator
    logger.go:42: 14:22:55 | operator/0- | test step completed 0-
=== CONT  kuttl/harness/prometheusexporter
    logger.go:42: 14:22:55 | prometheusexporter/1-prometheusexporter | PrometheusExporter:default/example-memcached created
=== CONT  kuttl/harness/operator
    logger.go:42: 14:22:55 | operator | operator events from ns kuttl-test-assuring-redfish:
    logger.go:42: 14:22:55 | operator | Deleting namespace: kuttl-test-assuring-redfish
=== CONT  kuttl/harness/prometheusexporter
    logger.go:42: 14:23:26 | prometheusexporter/1-prometheusexporter | test step completed 1-prometheusexporter
    logger.go:42: 14:23:26 | prometheusexporter | prometheusexporter events from ns kuttl-test-fit-ant:
    logger.go:42: 14:23:26 | prometheusexporter | Deleting namespace: kuttl-test-fit-ant
=== CONT  kuttl
    harness.go:399: run tests finished
    harness.go:508: cleaning up
    harness.go:563: removing temp folder: ""
--- PASS: kuttl (33.74s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/operator (1.23s)
        --- PASS: kuttl/harness/prometheusexporter (31.92s)
PASS

```
 
/kind feature
/priority important-soon
/assign