### PR TITLE
Fix e2e tests by upgrading kind version to v0.11.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ $(OPM):
 	chmod +x $(OPM)
 
 # Download kind locally if necessary
-KIND_RELEASE = v0.10.0
+KIND_RELEASE = v0.11.1
 KIND = $(shell pwd)/bin/kind-$(KIND_RELEASE)
 KIND_DL_URL = https://github.com/kubernetes-sigs/kind/releases/download/$(KIND_RELEASE)/kind-$(OS)-$(ARCH)
 $(KIND):


### PR DESCRIPTION
Upgrade kind to v0.11.1 to fix problems with the cluster startup in github actions, which forced e2e test to fail.

/kind bug
/priority important-soon
/assign

Happened also at https://github.com/3scale-ops/marin3r/pull/114