### PR TITLE
Feat/Upgrade operator-sdk to v1.24.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v1.13.1
+FROM quay.io/operator-framework/ansible-operator:v1.24.0
 
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.5.1-alpha.5
+VERSION ?= 0.6.0-alpha.2
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=prometheus-exporter-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.13.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.24.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=ansible.sdk.operatorframework.io/v1
 

--- a/bundle/manifests/prometheus-exporter-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/prometheus-exporter-operator.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
     operators.operatorframework.io/project_layout: ansible.sdk.operatorframework.io/v1
     repository: https://github.com/3scale-ops/prometheus-exporter-operator
     support: Red Hat, Inc.
-  name: prometheus-exporter-operator.v0.5.1-alpha.5
+  name: prometheus-exporter-operator.v0.6.0-alpha.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -124,7 +124,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/prometheus-exporter-operator:v0.5.1-alpha.5
+                image: quay.io/3scale/prometheus-exporter-operator:v0.6.0-alpha.2
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -307,4 +307,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.redhat.com
-  version: 0.5.1-alpha.5
+  version: 0.6.0-alpha.2

--- a/bundle/manifests/prometheus-exporter-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/prometheus-exporter-operator.clusterserviceversion.yaml
@@ -30,7 +30,7 @@ metadata:
     createdAt: "2020-06-08 00:00:00"
     description: Operator to setup 3rd party prometheus exporters, with a collection
       of grafana dashboards
-    operators.operatorframework.io/builder: operator-sdk-v1.13.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.24.0
     operators.operatorframework.io/project_layout: ansible.sdk.operatorframework.io/v1
     repository: https://github.com/3scale-ops/prometheus-exporter-operator
     support: Red Hat, Inc.
@@ -95,7 +95,9 @@ spec:
   install:
     spec:
       deployments:
-      - name: prometheus-exporter-operator-controller-manager
+      - label:
+          control-plane: controller-manager
+        name: prometheus-exporter-operator-controller-manager
         spec:
           replicas: 1
           selector:
@@ -104,6 +106,8 @@ spec:
           strategy: {}
           template:
             metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
               labels:
                 control-plane: controller-manager
             spec:
@@ -139,9 +143,18 @@ spec:
                   initialDelaySeconds: 5
                   periodSeconds: 10
                   timeoutSeconds: 5
-                resources: {}
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
+                  requests:
+                    cpu: 10m
+                    memory: 128Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: prometheus-exporter-operator-controller-manager

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: prometheus-exporter-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.13.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.24.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: ansible.sdk.operatorframework.io/v1
 

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -18,7 +18,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    image: quay.io/operator-framework/scorecard-test:v1.24.0
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -28,7 +28,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    image: quay.io/operator-framework/scorecard-test:v1.24.0
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -38,7 +38,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    image: quay.io/operator-framework/scorecard-test:v1.24.0
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -48,7 +48,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    image: quay.io/operator-framework/scorecard-test:v1.24.0
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -58,7 +58,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    image: quay.io/operator-framework/scorecard-test:v1.24.0
     labels:
       suite: olm
       test: olm-status-descriptors-test

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -9,8 +9,10 @@ namespace: prometheus-exporter-operator-system
 namePrefix: prometheus-exporter-operator-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+#labels:
+#- includeSelectors: true
+#  pairs:
+#    someName: someValue
 
 bases:
 - ../crd

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,16 +10,28 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - "ALL"
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
-        - "--v=10"
+        - "--v=0"
         ports:
         - containerPort: 8443
           protocol: TCP
           name: https
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
       - name: manager
         args:
         - "--health-probe-bind-address=:6789"

--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -8,3 +8,13 @@ metrics:
 leaderElection:
   leaderElect: true
   resourceName: 811c9dc5.3scale.net
+# leaderElectionReleaseOnCancel defines if the leader should step down volume
+# when the Manager ends. This requires the binary to immediately end when the
+# Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
+# speeds up voluntary leader transitions as the new leader don't have to wait
+# LeaseDuration time first.
+# In the default scaffold provided, the program ends immediately after
+# the manager stops, so would be fine to enable this option. However,
+# if you are doing or is intended to do any operation such as perform cleanups
+# after the manager stops then its usage might be unsafe.
+# leaderElectionReleaseOnCancel: true

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,4 +8,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/prometheus-exporter-operator
-  newTag: v0.5.1-alpha.5
+  newTag: v0.6.0-alpha.2

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -19,11 +19,20 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
     spec:
       securityContext:
         runAsNonRoot: true
+        # TODO(user): For common cases that do not require escalating privileges
+        # it is recommended to ensure that all your Pods/Containers are restrictive.
+        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
+        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
+        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
+        # seccompProfile:
+        #   type: RuntimeDefault
       containers:
       - args:
         - --leader-elect
@@ -39,6 +48,9 @@ spec:
               fieldPath: metadata.annotations['olm.targetNamespaces']
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - "ALL"
         livenessProbe:
           httpGet:
             path: /healthz
@@ -53,5 +65,12 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 128Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+- bases/prometheus-exporter-operator.clusterserviceversion.yaml
 - ../default
 - ../samples
 - ../scorecard

--- a/config/scorecard/patches/olm.config.yaml
+++ b/config/scorecard/patches/olm.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    image: quay.io/operator-framework/scorecard-test:v1.24.0
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -14,7 +14,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    image: quay.io/operator-framework/scorecard-test:v1.24.0
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -24,7 +24,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    image: quay.io/operator-framework/scorecard-test:v1.24.0
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -34,7 +34,7 @@
     entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    image: quay.io/operator-framework/scorecard-test:v1.24.0
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -44,7 +44,7 @@
     entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    image: quay.io/operator-framework/scorecard-test:v1.24.0
     labels:
       suite: olm
       test: olm-status-descriptors-test

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,7 +4,7 @@
   connection: local
   gather_facts: no
   collections:
-    - community.kubernetes
+    - kubernetes.core
 
   tasks:
     - name: Create Namespace

--- a/molecule/default/destroy.yml
+++ b/molecule/default/destroy.yml
@@ -4,7 +4,7 @@
   connection: local
   gather_facts: false
   collections:
-    - community.kubernetes
+    - kubernetes.core
 
   tasks:
     - import_tasks: kustomize.yml

--- a/molecule/default/kustomize.yml
+++ b/molecule/default/kustomize.yml
@@ -1,13 +1,20 @@
 ---
 - name: Build kustomize testing overlay
   # load_restrictor must be set to none so we can load patch files from the default overlay
-  command: '{{ kustomize }} build  --load_restrictor none .'
+  command: '{{ kustomize }} build --load-restrictor LoadRestrictionsNone'
   args:
     chdir: '{{ config_dir }}/testing'
   register: resources
   changed_when: false
 
 - name: Set resources to {{ state }}
+  k8s:
+    definition: '{{ item }}'
+    state: '{{ state }}'
+    wait: no
+  loop: '{{ resources.stdout | from_yaml_all | list }}'
+
+- name: Wait for resources to get to {{ state }}
   k8s:
     definition: '{{ item }}'
     state: '{{ state }}'

--- a/molecule/default/tasks/prometheusexporter_test.yml
+++ b/molecule/default/tasks/prometheusexporter_test.yml
@@ -7,8 +7,7 @@
     wait: yes
     wait_timeout: 300
     wait_condition:
-      type: Running
-      reason: Successful
+      type: Successful
       status: "True"
   vars:
     cr_file: 'monitoring_v1alpha1_prometheusexporter.yaml'

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -4,7 +4,7 @@
   connection: local
   gather_facts: no
   collections:
-    - community.kubernetes
+    - kubernetes.core
 
   vars:
     ctrl_label: control-plane=controller-manager

--- a/molecule/kind/destroy.yml
+++ b/molecule/kind/destroy.yml
@@ -4,7 +4,7 @@
   connection: local
   gather_facts: false
   collections:
-    - community.kubernetes
+    - kubernetes.core
 
   tasks:
     - name: Destroy test kind cluster

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,10 @@
 ---
 collections:
   - name: community.kubernetes
-    version: "1.2.1"
+    version: "2.0.1"
   - name: operator_sdk.util
-    version: "0.2.0"
+    version: "0.4.0"
+  - name: kubernetes.core
+    version: "2.3.1"
+  - name: cloud.common
+    version: "2.1.1"

--- a/roles/prometheusexporter/meta/main.yml
+++ b/roles/prometheusexporter/meta/main.yml
@@ -9,4 +9,4 @@ galaxy_info:
 dependencies: []
 collections:
 - operator_sdk.util
-- community.kubernetes
+- kubernetes.core

--- a/roles/prometheusexporter/tasks/main.yml
+++ b/roles/prometheusexporter/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Get information about existing api-groups in the cluster for PrometheusExporter {{ ansible_operator_meta.name }} on Namespace {{ ansible_operator_meta.namespace }}
   set_fact:
-    api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
+    api_groups: "{{ lookup('kubernetes.core.k8s', cluster_info='api_groups') }}"
 
 - name: Convert serviceMonitor.enabled boolean var into ansible service_monitor_state state var for PrometheusExporter {{ ansible_operator_meta.name }} on Namespace  { ansible_operator_meta.namespace }}
   set_fact:


### PR DESCRIPTION
- Upgrades operator-sdk from `v1.13.1` to `v1.24.0` (contains a few changes required for k8s 1.25)
- Updates `k8s` module name checking for available apis in the cluster, by the one in the new ansible collections, otherwise it fails on a FIPS enabled cluster https://github.com/ansible-collections/kubernetes.core/issues/494
```
An unhandled exception occurred while running the lookup plugin 'k8s'. Error was a <class 'ValueError'>, original message: [digital envelope routines: EVP_DigestInit_ex] disabled for FIPS
```
- Adds default resources to controller-manager (until now they were not set)
- Alpha release `v0.6.0-alpha.2` tested in development cluster

/kind feature
/priority important-soon
/assign