### PR TITLE
Feat/Update grafana dashboards showing negative values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.6.0-alpha.2
+VERSION ?= 0.6.0-alpha.3
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/prometheus-exporter-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/prometheus-exporter-operator.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
     operators.operatorframework.io/project_layout: ansible.sdk.operatorframework.io/v1
     repository: https://github.com/3scale-ops/prometheus-exporter-operator
     support: Red Hat, Inc.
-  name: prometheus-exporter-operator.v0.6.0-alpha.2
+  name: prometheus-exporter-operator.v0.6.0-alpha.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -124,7 +124,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/prometheus-exporter-operator:v0.6.0-alpha.2
+                image: quay.io/3scale/prometheus-exporter-operator:v0.6.0-alpha.3
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -307,4 +307,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.redhat.com
-  version: 0.6.0-alpha.2
+  version: 0.6.0-alpha.3

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,4 +8,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/prometheus-exporter-operator
-  newTag: v0.6.0-alpha.2
+  newTag: v0.6.0-alpha.3

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -36,7 +36,8 @@ mysql-create: ## MYSQL EXAMPLE - Create: CR-secret (connection string), CR-DB (w
 	$(KUBE_CLIENT) apply -f mysql/ --validate=false -n $(NAMESPACE)
 	sleep 30
 	$(KUBE_CLIENT) wait --timeout=180s --for condition=ready pod mysql-server-0 -n $(NAMESPACE)
-	$(KUBE_CLIENT) exec mysql-server-0 -n $(NAMESPACE) -- mysql -h localhost -u root -p123456789 -e "GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'exporter'@'%';"
+	$(KUBE_CLIENT) exec mysql-server-0 -n $(NAMESPACE) -- mysql -u root -h localhost -e "CREATE USER 'exporter'@'%' IDENTIFIED BY '123456789';"
+	$(KUBE_CLIENT) exec mysql-server-0 -n $(NAMESPACE) -- mysql -u root -h localhost -e "GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'exporter'@'%';"
 
 mysql-delete: ## MYSQL EXAMPLE - Delete: CR, CR-DB, CR-secret
 	$(KUBE_CLIENT) delete -f mysql/ -n $(NAMESPACE) || true

--- a/examples/mysql/mysql-db-service.yaml
+++ b/examples/mysql/mysql-db-service.yaml
@@ -18,19 +18,11 @@ spec:
         - name: mysql-server
           image: mysql:5.6
           env:
-            - name: MYSQL_USER
-              value: exporter
-            - name: MYSQL_PASSWORD
-              value: "123456789"
-            - name: MYSQL_ROOT_PASSWORD
-              value: "123456789"
+            - name: MYSQL_ALLOW_EMPTY_PASSWORD
+              value: "yes"
           readinessProbe:
-            exec:
-              command:
-              - /bin/sh
-              - -i
-              - -c
-              - mysql -h localhost -u root -p123456789 -e 'SELECT 1'
+            tcpSocket:
+              port: 3306
           resources:
             requests:
               cpu: 100m

--- a/roles/prometheusexporter/exporters/memcached/grafanadashboard.json.j2
+++ b/roles/prometheusexporter/exporters/memcached/grafanadashboard.json.j2
@@ -750,7 +750,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": 0,
           "show": true
         },
         {
@@ -758,7 +758,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": 0,
           "show": true
         }
       ],

--- a/roles/prometheusexporter/exporters/postgresql/grafanadashboard.json.j2
+++ b/roles/prometheusexporter/exporters/postgresql/grafanadashboard.json.j2
@@ -1508,7 +1508,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": 0,
           "show": true
         },
         {
@@ -1516,7 +1516,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": 0,
           "show": true
         }
       ],
@@ -1595,7 +1595,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": 0,
           "show": true
         },
         {
@@ -1603,7 +1603,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": 0,
           "show": true
         }
       ],
@@ -1898,7 +1898,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": 0,
           "show": true
         },
         {
@@ -1906,7 +1906,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": 0,
           "show": true
         }
       ],
@@ -2075,7 +2075,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": 0,
           "show": true
         },
         {
@@ -2083,7 +2083,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": 0,
           "show": true
         }
       ],


### PR DESCRIPTION
- A few dashboards whose specific metrics tends to be 0, are showing negative values because `Ymin=null` (which means is `auto`).
  - On some cases where values are very high, `Ymin=null (auto)` is good, because it adapts automatically to each value, making simpler to check the evolution:
    - Good having `Ymin=null (auto)`
![image](https://user-images.githubusercontent.com/41513123/197247040-e2dfc5da-75ab-46ad-a9cb-c7de53217409.png)
    - Instead of  `Ymin=0` (bad)
![image](https://user-images.githubusercontent.com/41513123/197246936-eb84494d-cf3c-448e-abff-c253e47bd505.png)
  - However, on some case where metrics tend to be 0, having `Ymin=null (auto)` means showing negative values on the panel, which makes no sense:
![image](https://user-images.githubusercontent.com/41513123/197246665-9b912e97-bd2b-4e0d-b342-dfa5301f83dd.png)
    - This PR fixes a few cases on memcached and postgres grafana dashboards where it is better to have `Ymin=0`

- In addition, it simplifies the mysql database example used to show how the exporter can be deployed, because it stopped working after last time it was checked.

- Alpha release `v0.6.0-alpha.3` has been successfully tested in development cluster.

/kind bug
/priority important-soon
/assign