### PR TITLE
Bug/Increase resources limits and Stable release v0.6.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.6.0
+VERSION ?= 0.6.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/prometheus-exporter-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/prometheus-exporter-operator.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
     operators.operatorframework.io/project_layout: ansible.sdk.operatorframework.io/v1
     repository: https://github.com/3scale-ops/prometheus-exporter-operator
     support: Red Hat, Inc.
-  name: prometheus-exporter-operator.v0.6.0
+  name: prometheus-exporter-operator.v0.6.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -124,7 +124,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/prometheus-exporter-operator:v0.6.0
+                image: quay.io/3scale/prometheus-exporter-operator:v0.6.1
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -145,8 +145,8 @@ spec:
                   timeoutSeconds: 5
                 resources:
                   limits:
-                    cpu: 500m
-                    memory: 512Mi
+                    cpu: "1"
+                    memory: 1Gi
                   requests:
                     cpu: 10m
                     memory: 128Mi
@@ -307,4 +307,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.redhat.com
-  version: 0.6.0
+  version: 0.6.1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,4 +8,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/prometheus-exporter-operator
-  newTag: v0.6.0
+  newTag: v0.6.1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -67,8 +67,8 @@ spec:
           timeoutSeconds: 5
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 1000m
+            memory: 1024Mi
           requests:
             cpu: 10m
             memory: 128Mi


### PR DESCRIPTION
Prior to operator-sdk 1.24.0, controller-manager resources were not set. In https://github.com/3scale-ops/prometheus-exporter-operator/pull/43 resources requests/limits were set using lower values from default operator-sdk-ansible, as resources obtained from deployed operator on different clusters were very low.

With previous stable release v0.6.0 https://github.com/3scale-ops/prometheus-exporter-operator/pull/45, operator was deployed in staging, and reconciles were failing with weird errors:

```json
{"level":"error","ts":1666617288.0895257,"logger":"reconciler","msg":"\u001b[0;34mansible-playbook 2.9.27\u001b[0m\r\n\u001b[0;34m  config file = /etc/ansible/ansible.cfg\u001b[0m\r\n\u001b[0;34m  configured module search path = ['/usr/share/ansible/openshift']\u001b[0m\r\n\u001b[0;34m  ansible python module location = /usr/local/lib/python3.8/site-packages/ansible\u001b[0m\r\n\u001b[0;34m  executable location = /usr/local/bin/ansible-playbook\u001b[0m\r\n\u001b[0;34m  python version = 3.8.12 (default, Sep 16 2021, 10:46:05) [GCC 8.5.0 20210514 (Red Hat 8.5.0-3)]\u001b[0m\r\n\u001b[0;34mUsing /etc/ansible/ansible.cfg as config file\u001b[0m\r\n\u001b[0;34mSkipping callback 'actionable', as we already have a stdout callback.\u001b[0m\n\u001b[0;34mSkipping callback 'awx_display', as we already have a stdout callback.\u001b[0m\n\u001b[0;34mSkipping callback 'counter_enabled', as we already have a stdout callback.\u001b[0m\n\u001b[0;34mSkipping callback 'debug', as we already have a stdout callback.\u001b[0m\n...

{"level":"error","ts":1666617288.0907607,"msg":"Reconciler error","controller":"prometheusexporter-controller","object":{"name":"stg-saas-system-rds-mysql","namespace":"prometheus-exporter"},"namespace":"prometheus-exporter","name":"stg-saas-system-rds-mysql","reconcileID":"015dc53e-2d6d-44e6-bddf-0728fb383125","error":"did not receive playbook_on_stats event","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:273\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:234"}

{"level":"error","ts":1666617288.788181,"logger":"runner","msg":"\u001b[0;34mansible-playbook 2.9.27\u001b[0m\r\n\u001b[0;34m  config file = /etc/ansible/ansible.cfg\u001b[0m\r\n\u001b[0;34m  configured module search path = ['/usr/share/ansible/openshift']\u001b[0m\r\n\u001b[0;34m  ansible python module location = /usr/local/lib/python3.8/site-packages/ansible\u001b[0m\r\n\u001b[0;34m  executable location = /usr/local/bin/ansible-playbook\u001b[0m\r\n\u001b[0;34m  python version = 3.8.12 (default, Sep 16 2021, 10:46:05) [GCC 8.5.0 20210514 (Red Hat 8.5.0-3)]\u001b[0m\r\n\u001b[0;34mUsing /etc/ansible/ansible.cfg as config file\u001b[0m\r\n\u001b[0;34mSkipping callback 'actionable', as we already have a stdout callback.\u001b[0m\n\u001b[0;34mSkipping callback 'awx_display', as we already have a stdout callback.\u001b[0m\n\u001b[0;34mSkipping callback 'counter_enabled', as we already have a stdout callback.\u001b[0m\n\u001b[0;34mSkipping callback 'debug', as we already have a stdout callback.\u001b[0m\n\u001...
```

Checking operator-sdk repository issues there is nothing (just an old issue saying that indicates ansible-runner is not running), so I start investigating why these errors appears in staging but not in development.

I have installed the same **prometheus-exporter-operator:v0.6.0** on another Namespace from same cluster, deployed a couple of sample `PrometheusExporter` CRs and it works fine.

The difference between the one failing and the one succeeding, is that the one failing has 10 CRs to reconcile, while the one without problems only 2.

So the problem comes when the controller-manager pod starts and has to reconcile many resources (10 in that case), and it needs a lot of initial resources (both CPU/memory).

I have updated temporarily the Operator **Subscription** to have greater memory resources (728MI was the default from operator-sdk-ansible)

```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: prometheus-exporter-operator
  namespace: prometheus-exporter
spec:
  channel: stable
  installPlanApproval: Automatic
  name: prometheus-exporter-operator
  source: prometheus-exporter-operator-catalog
  sourceNamespace: prometheus-exporter
  config:
    resources:
      requests:
        memory: "128Mi"
        cpu: "10m"
      limits:
        memory: "728Mi"
        cpu: "500m"
```

And it worked successfully, reconciles start to **Success** (before they were constantly on **Running** state). In the image half of reconciles have succeeded, while the others are still running:
![image](https://user-images.githubusercontent.com/41513123/197549207-129bf897-d3ff-45b4-8255-752733e1d967.png)

Checking used resources on the initial reconcile of the 10 custom resources:
- Memory grow to the configured limit (728MI) and 7minutes later decreases to stable 34MB
![image](https://user-images.githubusercontent.com/41513123/197550221-87852659-94c3-4f8e-affc-9eaf6a2086a6.png)
- CPU grow to the configured limit (500m) and 10minutes later decreases to stable 0,001m (nothing)
![image](https://user-images.githubusercontent.com/41513123/197550333-ef86452d-e624-4377-82a0-8c8dd54d5451.png)

So this PR increases the resources limits to higher values (it arrived to the limit with 10 CRs), that might seem very high compared to idle values, but they need to be there just for the initial reconcile, otherwise won't work.


/kind bug
/kind release
/priority important-soon
/assign