### PR TITLE
fix/cross-namespace-dashboard-import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.8.0
+VERSION ?= 0.8.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/prometheus-exporter-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/prometheus-exporter-operator.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
     operators.operatorframework.io/project_layout: ansible.sdk.operatorframework.io/v1
     repository: https://github.com/3scale-ops/prometheus-exporter-operator
     support: Red Hat, Inc.
-  name: prometheus-exporter-operator.v0.8.0
+  name: prometheus-exporter-operator.v0.8.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -125,7 +125,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/prometheus-exporter-operator:v0.8.0
+                image: quay.io/3scale/prometheus-exporter-operator:v0.8.1
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -310,4 +310,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.redhat.com
-  version: 0.8.0
+  version: 0.8.1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,4 +8,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/prometheus-exporter-operator
-  newTag: v0.8.0
+  newTag: v0.8.1

--- a/roles/prometheusexporter/templates/grafanadashboard.yml.j2
+++ b/roles/prometheusexporter/templates/grafanadashboard.yml.j2
@@ -14,6 +14,7 @@ metadata:
 {% endif %}
 spec:
 {% if grafana_dashboard_api_version == "v1beta1" %}
+  allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
       "{{ grafana_dashboard.label.key | default(grafana_dashboard_label_key) }}": "{{ grafana_dashboard.label.value | default(grafana_dashboard_label_value) }}"


### PR DESCRIPTION
Cross namespace import does not work when using v1beta1 grafana-operator API, as it does for v1alpha1. This PR fixes it.

/kind bug
/priority important-soon
/assign