### PR TITLE
Fix test-e2e make  target 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,5 +267,5 @@ kind-deploy: docker-build $(KIND) ## Deploys the operator in the k8s kind cluste
 	$(KUSTOMIZE) build config/testing | kubectl apply -f -
 
 test-e2e: export KUBECONFIG = ${PWD}/kubeconfig
-test-e2e: kind-create kind-deploy $(KUTTL) ## Run kuttl e2e tests in the k8s kind cluster
+test-e2e: kind-create kustomize kind-deploy $(KUTTL) ## Run kuttl e2e tests in the k8s kind cluster
 	$(KUTTL) test


### PR DESCRIPTION
With a new laptop with no local kustomize installed, make `test-e2e` target was failing if your first make target execution was the `test-e2e`, as until now `kustomize` target was called on other targets but no `test-e2e`.

Now `kustomize` target has been added to be executed also with `test-e2e`, so now it works independingly of which target do you execute first.

/kind bug
/priority important-soon
/assign