### PR TITLE
Update grafana-operator label selector from all examples to match default operator value

### DIFF
--- a/config/samples/monitoring_v1alpha1_prometheusexporter.yaml
+++ b/config/samples/monitoring_v1alpha1_prometheusexporter.yaml
@@ -6,7 +6,7 @@ spec:
   type: memcached
   grafanaDashboard:
     label:
-      key: autodiscovery
+      key: discovery
       value: enabled
   dbHost: your-memcached-host
   dbPort: 11211

--- a/docs/prometheus-exporter-crd-reference.md
+++ b/docs/prometheus-exporter-crd-reference.md
@@ -17,8 +17,8 @@ spec:
   grafanaDashboard:
     enabled: true
     label:
-      key: monitoring-key
-      value: middleware
+      key: discovery
+      value: enabled
     apiVersion: grafana.integreatly.org/v1beta1
   extraLabel:
     key: tier

--- a/examples/cloudwatch/cloudwatch-cr.yaml
+++ b/examples/cloudwatch/cloudwatch-cr.yaml
@@ -6,7 +6,7 @@ spec:
   type: cloudwatch
   grafanaDashboard:
     label:
-      key: monitoring-key
-      value: middleware
+      key: discovery
+      value: enabled
   awsCredentialsSecretName: prometheus-exporter-cloudwatch-staging-aws-cw
   configurationConfigmapName: prometheus-exporter-cloudwatch-staging-aws-cw

--- a/examples/elasticsearch/es-cr.yaml
+++ b/examples/elasticsearch/es-cr.yaml
@@ -6,7 +6,7 @@ spec:
   type: es
   grafanaDashboard:
     label:
-      key: monitoring-key
-      value: middleware
+      key: discovery
+      value: enabled
   dbHost: https://vpc-staging-es.us-east-1.es.amazonaws.com
   dbPort: 443

--- a/examples/manticore/manticore-cr.yaml
+++ b/examples/manticore/manticore-cr.yaml
@@ -6,8 +6,8 @@ spec:
   type: manticore
   grafanaDashboard:
     label:
-      key: monitoring-key
-      value: middleware
+      key: discovery
+      value: enabled
   extraLabel:
     key: threescale_component
     value: system

--- a/examples/memcached/memcached-cr.yaml
+++ b/examples/memcached/memcached-cr.yaml
@@ -6,8 +6,8 @@ spec:
   type: memcached
   grafanaDashboard:
     label:
-      key: monitoring-key
-      value: middleware
+      key: discovery
+      value: enabled
   extraLabel:
     key: threescale_component
     value: system

--- a/examples/mysql/mysql-cr.yaml
+++ b/examples/mysql/mysql-cr.yaml
@@ -6,8 +6,8 @@ spec:
   type: mysql
   grafanaDashboard:
     label:
-      key: monitoring-key
-      value: middleware
+      key: discovery
+      value: enabled
   extraLabel:
     key: threescale_component
     value: system

--- a/examples/postgresql/postgresql-cr.yaml
+++ b/examples/postgresql/postgresql-cr.yaml
@@ -6,8 +6,8 @@ spec:
   type: postgresql
   grafanaDashboard:
     label:
-      key: monitoring-key
-      value: middleware
+      key: discovery
+      value: enabled
   extraLabel:
     key: threescale_component
     value: zync

--- a/examples/probe/probe-cr.yaml
+++ b/examples/probe/probe-cr.yaml
@@ -6,6 +6,6 @@ spec:
   type: probe
   grafanaDashboard:
     label:
-      key: monitoring-key
-      value: middleware
+      key: discovery
+      value: enabled
   configurationConfigmapName: prometheus-exporter-probe-staging-blackbox

--- a/examples/redis/redis-cr-2.yaml
+++ b/examples/redis/redis-cr-2.yaml
@@ -6,8 +6,8 @@ spec:
   type: redis
   grafanaDashboard:
     label:
-      key: monitoring-key
-      value: middleware
+      key: discovery
+      value: enabled
   extraLabel:
     key: threescale_component
     value: system

--- a/examples/redis/redis-cr.yaml
+++ b/examples/redis/redis-cr.yaml
@@ -6,8 +6,8 @@ spec:
   type: redis
   grafanaDashboard:
     label:
-      key: monitoring-key
-      value: middleware
+      key: discovery
+      value: enabled
   extraLabel:
     key: threescale_component
     value: backend

--- a/examples/sendgrid/sendgrid-cr.yaml
+++ b/examples/sendgrid/sendgrid-cr.yaml
@@ -6,6 +6,6 @@ spec:
   type: sendgrid
   grafanaDashboard:
     label:
-      key: monitoring-key
-      value: middleware
+      key: discovery
+      value: enabled
   sendgridCredentialsSecretName: prometheus-exporter-sendgrid-production

--- a/examples/sphinx/sphinx-cr.yaml
+++ b/examples/sphinx/sphinx-cr.yaml
@@ -6,8 +6,8 @@ spec:
   type: sphinx
   grafanaDashboard:
     label:
-      key: monitoring-key
-      value: middleware
+      key: discovery
+      value: enabled
   extraLabel:
     key: threescale_component
     value: system

--- a/test/e2e/prometheusexporter-grafanadashboard-apiversion/01-prometheusexporter.yaml
+++ b/test/e2e/prometheusexporter-grafanadashboard-apiversion/01-prometheusexporter.yaml
@@ -7,7 +7,7 @@ spec:
   type: memcached
   grafanaDashboard:
     label:
-      key: autodiscovery
+      key: discovery
       value: enabled
     apiVersion: v1beta1
   dbHost: your-memcached-host

--- a/test/e2e/prometheusexporter/01-prometheusexporter.yaml
+++ b/test/e2e/prometheusexporter/01-prometheusexporter.yaml
@@ -7,7 +7,7 @@ spec:
   type: memcached
   grafanaDashboard:
     label:
-      key: autodiscovery
+      key: discovery
       value: enabled
   dbHost: your-memcached-host
   dbPort: 11211


### PR DESCRIPTION
The example of grafana label selector used on different places (docs, CSV example, real examples, tests...) has been updated to match current default value of the operator.

Actually, previous label `monitoring-key` produces errors on grafana-operator v5.

/kind documentation
/priority important-soon
/assign