### PR TITLE
feat: new gh actions workflows

### DIFF
--- a/.github/workflows/release-catalog.yaml
+++ b/.github/workflows/release-catalog.yaml
@@ -1,0 +1,59 @@
+name: release-catalog
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - catalog/**/stable-channel.yaml
+
+jobs:
+  check:
+    name: Check if it's a stable release
+    runs-on: ubuntu-24.04
+    outputs:
+      stable-release: ${{ env.NEW_RELEASE }}
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: actions/cache@v4.1.2
+        with:
+          key: ${{ runner.os }}-bin
+          path: ./bin
+
+      - id: new-release
+        name: Check if it's a stable release
+        run: |
+          echo "NEW_RELEASE=$(make get-new-release)" >> $GITHUB_ENV
+
+  build:
+    if: needs.check.outputs.stable-release != ''
+    name: Build and push the catalog release image
+    needs: check
+    runs-on: ubuntu-24.04
+    env:
+      RELEASE: ${{ needs.check.outputs.stable-release }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: actions/cache@v4.1.2
+        with:
+          key: ${{ runner.os }}-bin
+          path: ./bin
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to quay.io/3scale
+        uses: docker/login-action@v3
+        with:
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+          registry: quay.io
+          username: ${{ secrets.REGISTRY_USER }}
+
+      - name: Build and push bundle container image
+        run: make catalog-push

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,97 @@
+name: release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - bundle/manifests/**
+
+jobs:
+  check:
+    name: Check if it's a stable release
+    runs-on: ubuntu-24.04
+    outputs:
+      stable-release: ${{ env.NEW_RELEASE }}
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: actions/cache@v4.1.2
+        with:
+          key: ${{ runner.os }}-bin
+          path: ./bin
+
+      - id: new-release
+        name: Check if it's a stable release
+        run: |
+          echo "NEW_RELEASE=$(make get-new-release)" >> $GITHUB_ENV
+
+  build:
+    if: needs.check.outputs.stable-release != ''
+    name: Build and push the stable release images for the operator and the bundle
+    needs: check
+    runs-on: ubuntu-24.04
+    env:
+      RELEASE: ${{ needs.check.outputs.stable-release }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: actions/cache@v4.1.2
+        with:
+          key: ${{ runner.os }}-bin
+          path: ./bin
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to quay.io/3scale
+        uses: docker/login-action@v3
+        with:
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+          registry: quay.io
+          username: ${{ secrets.REGISTRY_USER }}
+
+      - name: Build and push operator container image
+        run: make container-push
+
+      - name: Build and push bundle container image
+        run: make bundle-push
+
+      - id: bundle-image-name
+        name: Retrieves the bundle image name
+        run: echo  "BUNDLE_IMAGE=$(make -s bundle-image-name)" >> $GITHUB_OUTPUT
+
+      - name: Update catalog files with the new bundle
+        run: make catalog-update
+
+      - name: Create a new draft-release in github
+        run: gh release create "${{ env.RELEASE }}" --draft --title "${{ env.RELEASE }}" --generate-notes
+
+      - env:
+          CI_COMMIT_AUTHOR_EMAIL: 3scale-robot@users.noreply.github.com
+          CI_COMMIT_AUTHOR_NAME: 3scale-robot
+          CATALOG_RELEASE_BRANCH: catalog/${{ needs.check.outputs.stable-release }}
+          CATALOG_RELEASE_PR_TITLE: "release: catalog for bundle ${{ needs.check.outputs.stable-release }}"
+          CATALOG_RELEASE_PR_BODY: |
+            This PR updates the catalog inventory files with the new bundle [${{ needs.check.outputs.stable-release }}](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${{ needs.check.outputs.stable-release }}).
+
+            [${{ steps.bundle-image-name.outputs.BUNDLE_IMAGE }}](https://${{ steps.bundle-image-name.outputs.BUNDLE_IMAGE }})
+
+            Please review and merge this PR to build and release the new catalog.
+
+            /kind release
+            /priority important-soon
+        name: GIT commit and push catalog
+        run: |
+          git config --global user.name "${{ env.CI_COMMIT_AUTHOR_NAME }}"
+          git config --global user.email "${{ env.CI_COMMIT_AUTHOR_EMAIL }}"
+          git ls-remote --exit-code --heads origin refs/heads/${{ env.CATALOG_RELEASE_BRANCH }} && git push origin -d ${{ env.CATALOG_RELEASE_BRANCH }}
+          git checkout -b ${{ env.CATALOG_RELEASE_BRANCH }}
+          git add catalog
+          git commit -m "${{ env.CATALOG_RELEASE_PR_TITLE }}"
+          git push --set-upstream origin ${{ env.CATALOG_RELEASE_BRANCH }}
+          gh pr create -B main -H ${{ env.CATALOG_RELEASE_BRANCH }} --title "${{ env.CATALOG_RELEASE_PR_TITLE }}" --body "${{ env.CATALOG_RELEASE_PR_BODY }}"

--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,9 @@ CATALOG_CONTAINER_CTX = "catalog/"
 # Default catalog base image to append bundles to
 CATALOG_BASE_IMG ?= $(IMAGE_TAG_BASE)-catalog:latest
 
+# Default catalog channel file
+CATALOG_CHANNEL_FILE ?= catalog/prometheus-exporter-operator/stable-channel.yaml
+
 # Set CATALOG_BASE_IMG to an existing catalog image tag to add $BUNDLE_IMGS to that image.
 ifneq ($(origin CATALOG_BASE_IMG), undefined)
 FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG)
@@ -214,7 +217,7 @@ catalog-render: opm ## Render the clusterserviceversion yaml
 	$(OPM) render $(BUNDLE_IMGS) -oyaml > catalog/prometheus-exporter-operator/objects/prometheus-exporter-operator.v$(VERSION).clusterserviceversion.yaml
 
 catalog-add-entry: ## Add catalog entry if missing
-	grep -q 'name: prometheus-exporter-operator.v$(VERSION)' $(CATALOG_CHANNEL_FILE) || \
+	grep -Eq 'name: prometheus-exporter-operator\.v$(VERSION)$$' $(CATALOG_CHANNEL_FILE) || \
 		yq -i '.entries += {"name": "prometheus-exporter-operator.v$(VERSION)","replaces":"$(shell yq '.entries[-1].name' $(CATALOG_CHANNEL_FILE))"}' $(CATALOG_CHANNEL_FILE)
 
 .PHONY: catalog-add-bundle-to-alpha

--- a/README.md
+++ b/README.md
@@ -4,39 +4,41 @@
 
 [![test](https://github.com/3scale-ops/prometheus-exporter-operator/actions/workflows/test.yaml/badge.svg)](https://github.com/3scale-ops/prometheus-exporter-operator/actions/workflows/test.yaml)
 [![build](https://github.com/3scale-ops/prometheus-exporter-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/3scale-ops/prometheus-exporter-operator/actions/workflows/release.yaml)
+[![catalog](https://github.com/3scale-ops/prometheus-exporter-operator/actions/workflows/release-catalog.yaml/badge.svg)](https://github.com/3scale-ops/prometheus-exporter-operator/actions/workflows/release-catalog.yaml)
 [![release](https://badgen.net/github/release/3scale-ops/prometheus-exporter-operator)](https://github.com/3scale-ops/prometheus-exporter-operator/releases)
 [![license](https://badgen.net/github/license/3scale-ops/prometheus-exporter-operator)](https://github.com/3scale-ops/prometheus-exporter-operator/blob/main/LICENSE)
 
 A Kubernetes Operator based on the Operator SDK to centralize the setup of 3rd party prometheus exporters on **Kubernetes/OpenShift**, with a collection of grafana dashboards.
 
-By just providing a few parameters like *dbHost* or *dbPort* (operator manage the container image, port, argument, command, volumes... and also prometheus `ServiceMonitor` and `GrafanaDashboard` k8s objects), you can setup different prometheus exporters to monitor:
-* The **internals from different databases**
-* **HTTP/TCP endpoints** (availability, latency, SSL/TLS certificate expiration...)
-* Any available **cloudwatch metric from any AWS Service**
-* Sendgrid email statistics (delivered, bounces, errors. spam...)
+By just providing a few parameters like _dbHost_ or _dbPort_ (operator manage the container image, port, argument, command, volumes... and also prometheus `ServiceMonitor` and `GrafanaDashboard` k8s objects), you can setup different prometheus exporters to monitor:
+
+- The **internals from different databases**
+- **HTTP/TCP endpoints** (availability, latency, SSL/TLS certificate expiration...)
+- Any available **cloudwatch metric from any AWS Service**
+- Sendgrid email statistics (delivered, bounces, errors. spam...)
 
 Current prometheus exporters `types` supported, managed by same prometheus-exporter-operator:
-* memcached
-* redis
-* mysql
-* postgresql
-* sphinx
-* manticore
-* es (elasticsearch)
-* cloudwatch
-* probe (blackbox)
-* sendgrid
+
+- memcached
+- redis
+- mysql
+- postgresql
+- sphinx
+- manticore
+- es (elasticsearch)
+- cloudwatch
+- probe (blackbox)
+- sendgrid
 
 The operator manages the lifecycle of the following objects:
-* Deployment (one per CR)
-* Service (one per CR)
-* ServiceMonitor (optional, one per CR)
-* GrafanaDashboard (optional, one per Namespace)
 
-> **NOTE**
-><br /> Some exporters need some **extra objects to be previously manually created** in order to work (**manual objects names need to be specified on required CR fields**). This extra needed objects includes **Secrets (credentials) or Configmaps (configuration files) on specific formats**. Examples to help you create these extra objects are provided on [examples](examples/) directory for all exporter types.
-><br />
-><br /> **If you modify the content of these extra needed objects (*Secrets*/*Configmaps*), exporters won't load them automatically, so you need to force a new pod creation by for example deleting the running pod.**
+- Deployment (one per CR)
+- Service (one per CR)
+- ServiceMonitor (optional, one per CR)
+- GrafanaDashboard (optional, one per Namespace)
+
+> **NOTE** ><br /> Some exporters need some **extra objects to be previously manually created** in order to work (**manual objects names need to be specified on required CR fields**). This extra needed objects includes **Secrets (credentials) or Configmaps (configuration files) on specific formats**. Examples to help you create these extra objects are provided on [examples](examples/) directory for all exporter types.
+> <br /> ><br /> **If you modify the content of these extra needed objects (_Secrets_/_Configmaps_), exporters won't load them automatically, so you need to force a new pod creation by for example deleting the running pod.**
 
 ## Current status
 
@@ -44,62 +46,74 @@ Operator is available at [OperatorHub.io](https://operatorhub.io/operator/promet
 
 ## Requirements
 
-* [prometheus-operator](https://github.com/coreos/prometheus-operator) v0.17.0+
-* [grafana-operator](https://github.com/integr8ly/grafana-operator) v3.0.0+
+- [prometheus-operator](https://github.com/coreos/prometheus-operator) v0.17.0+
+- [grafana-operator](https://github.com/integr8ly/grafana-operator) v3.0.0+
 
 ## Documentation
 
-* [PrometheusExporter Custom Resource Reference](docs/prometheus-exporter-crd-reference.md)
-* [Install](docs/install.md)
-* [Development](docs/development.md)
-* [Examples](examples/)
-* [Release](docs/release.md)
+- [PrometheusExporter Custom Resource Reference](docs/prometheus-exporter-crd-reference.md)
+- [Install](docs/install.md)
+- [Development](docs/development.md)
+- [Examples](examples/)
+- [Release](docs/release.md)
 
 ## GrafanaDashboards
 
 `GrafanaDashboards` management is included in the operator:
-* For each CR, a `GrafanaDashboard` (optional, enabled by default `grafanaDashboard.enabled: true`) is created, but actually operator manages a single dashboard type per Namespace (not per CR)
-* If you deploy for example different redis CRs, and you want to have the redis dashboard created, you need to enabled it on every redis CR with the same grafana-operator label selector (but actually, operator will just manage a single dashboard per Namespace shared accross all CRs from the same type)
-* You can deploy the prometheus-exporter-operator with different operator versions on different Namespaces, so operator will create separate dashboards per Namespace (they won't collision, that's why dashboard name includes the Namespace)
-* All grafana dashboards are preconfigured to use `CR_NAME` as the filter of all possible dashboards of every type (for example `staging-system-memcached`)
-* *In the future it is possible that `GrafanaDashboard` management get its own CRD separate from `PrometheusExporter` CRD (so you could have N PrometheusExporter CRs, and also an additonal single Dashboard CR per exporter type*
+
+- For each CR, a `GrafanaDashboard` (optional, enabled by default `grafanaDashboard.enabled: true`) is created, but actually operator manages a single dashboard type per Namespace (not per CR)
+- If you deploy for example different redis CRs, and you want to have the redis dashboard created, you need to enabled it on every redis CR with the same grafana-operator label selector (but actually, operator will just manage a single dashboard per Namespace shared accross all CRs from the same type)
+- You can deploy the prometheus-exporter-operator with different operator versions on different Namespaces, so operator will create separate dashboards per Namespace (they won't collision, that's why dashboard name includes the Namespace)
+- All grafana dashboards are preconfigured to use `CR_NAME` as the filter of all possible dashboards of every type (for example `staging-system-memcached`)
+- _In the future it is possible that `GrafanaDashboard` management get its own CRD separate from `PrometheusExporter` CRD (so you could have N PrometheusExporter CRs, and also an additonal single Dashboard CR per exporter type_
 
 ### Memcached example dashboard
+
 <img src="img/example-memcached-dashboard.png" height="250px" alt="Example Memcached Dashboard"></img>
 
 ### Redis example dashboard
+
 <img src="img/example-redis-dashboard.png" height="250px" alt="Example Redis Dashboard"></img>
 
 ### MySQL example dashboard
+
 <img src="img/example-mysql-dashboard.png" height="250px" alt="Example MySQL Dashboard"></img>
 
 ### PostgreSQL example dashboard
+
 <img src="img/example-postgresql-dashboard.png" height="250px" alt="Example PostgreSQL Dashboard"></img>
 
 ### Sphinx example dashboard
+
 <img src="img/example-sphinx-dashboard.png" height="250px" alt="Example Sphinx Dashboard"></img>
 
 ### Manticore example dashboard
+
 <img src="img/example-manticore-dashboard.png" height="250px" alt="Example Manticore Dashboard"></img>
 
 ### Elasticsearch example dashboard
+
 <img src="img/example-es-dashboard.png" height="250px" alt="Example Elasticsearch Dashboard"></img>
 
 ### AWS CloudWatch example dashboard
+
 <img src="img/example-cloudwatch-dashboard.png" height="250px" alt="Example AWS Cloudwatch Dashboard"></img>
 
 ### Blackbox probe example dashboard
+
 <img src="img/example-probe-dashboard.png" height="250px" alt="Example Blackbox Probe Dashboard"></img>
 
 ### Sendgrid example dashboard
+
 <img src="img/example-sendgrid-dashboard.png" height="250px" alt="Example Sendgrid Dashboard"></img>
 
 ## PrometheusRules
 
 `PrometheusRules` management is NOT included in the operator (at least by the moment), because it depends on:
-* What you need to monitor (maybe ones just need basic cpu/mem alerts, while others may be interested on specific alerts checking internals of a database)
-* Why you want to be paged (severity warning/critical, minutes duration before firing an alert...)
-* Customizable thresholds definition (it is something that depends on infrastructure dimensions...)
+
+- What you need to monitor (maybe ones just need basic cpu/mem alerts, while others may be interested on specific alerts checking internals of a database)
+- Why you want to be paged (severity warning/critical, minutes duration before firing an alert...)
+- Customizable thresholds definition (it is something that depends on infrastructure dimensions...)
 
 However, some examples of prometheus rules can be found at [prometheus-rules](prometheus-rules/) directory.
 
@@ -107,11 +121,11 @@ However, some examples of prometheus rules can be found at [prometheus-rules](pr
 
 You can contribute by:
 
-* Raising any issues you find using Prometheus Exporter Operator
-* Fixing issues by opening [Pull Requests](https://github.com/3scale-ops/prometheus-exporter-operator/pulls)
-* Submitting a patch or opening a PR
-* Improving documentation
-* Talking about Prometheus Exporter Operator
+- Raising any issues you find using Prometheus Exporter Operator
+- Fixing issues by opening [Pull Requests](https://github.com/3scale-ops/prometheus-exporter-operator/pulls)
+- Submitting a patch or opening a PR
+- Improving documentation
+- Talking about Prometheus Exporter Operator
 
 All bugs, tasks or enhancements are tracked as [GitHub issues](https://github.com/3scale-ops/prometheus-exporter-operator/issues).
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,19 +1,36 @@
 # Release
 
-* Update Makefile variable `VERSION` to the appropiate release version. Allowed formats:
-  * alpha: `VERSION ?= 0.3.0-alpha.12`
-  * stable: `VERSION ?= 0.3.0`
+- Update Makefile variable `VERSION` to the appropiate release version. Allowed formats:
+  - alpha: `VERSION ?= 0.3.0-alpha.12`
+  - stable: `VERSION ?= 0.3.0`
 
 ## Alpha
-* If it is an **alpha** release, execute the following target to create appropiate `alpha` bundle files:
+
+- If it is an **alpha** release, execute the following target to create appropiate `alpha` bundle files:
+
 ```bash
 make prepare-alpha-release
 ```
-* Then you can manually execute opeator, bundle and catalog build/push.
+
+- Then you can manually execute opeator, bundle and catalog build/push.
+
+```bash
+make release-publish
+```
 
 ## Stable
-* But if it is an **stable** release, execute the following target to create appropiate `alpha` and `stable` bundle files:
+
+- But if it is an **stable** release, execute the following target to create appropiate `alpha` and `stable` bundle files:
+
 ```bash
 make prepare-stable-release
 ```
-* Then open a [Pull Request](https://github.com/3scale-ops/prometheus-exporter-operator/pulls), and a GitHub Action will automatically detect if it is new release or not, in order to create it by building/pushing new operator, bundle and catalog images, as well as creating a GitHub release draft.
+
+- Then open a [Pull Request](https://github.com/3scale-ops/prometheus-exporter-operator/pulls), and the [Release GitHub Action](https://github.com/3scale-ops/prometheus-exporter-operator/actions/workflows/release.yaml) will automatically detect if it is new release or not, in order to create it by building/pushing new operator and bundle.
+
+- As part of the release workflow, a:
+
+  - Release Draft will be published, review the changelog, adding any missing information and publish the release.
+  - A new Pull Request will opem with the updated catalog including the new release.
+
+- Review the Catalog Pull Request and merge it to publish the trigger the [Release Catalog GitHub Action](https://github.com/3scale-ops/prometheus-exporter-operator/actions/workflows/release-catalog.yaml). This action will automatically build and publish the new catalog image.

--- a/docs/release.md
+++ b/docs/release.md
@@ -31,6 +31,6 @@ make prepare-stable-release
 - As part of the release workflow, a:
 
   - Release Draft will be published, review the changelog, adding any missing information and publish the release.
-  - A new Pull Request will opem with the updated catalog including the new release.
+  - A new Pull Request will open with the updated catalog including the new release.
 
 - Review the Catalog Pull Request and merge it to publish the trigger the [Release Catalog GitHub Action](https://github.com/3scale-ops/prometheus-exporter-operator/actions/workflows/release-catalog.yaml). This action will automatically build and publish the new catalog image.


### PR DESCRIPTION
- Adds a new GH actions workflow

  - `release` workflow, triggered on `bundle/manifests/**` changes in the main branch
     -  checks if the HEAD release is stable
     -  if it's stable
        - builds and pushes the operator container image
        - builds and pushes the bundle container image
        - drafts a new release for the stable version
        - generates the new catalog files
        - creates a PR with the new catalog files to release a new catalog version using the `release-catalog` workflow


  - `release-catalog` workflow, triggered on `catalog/**/stable-channel.yaml` changes in the main branch
     -  checks if the HEAD release is stable
     -  if it's stable
        -  builds and pushes a new catalog image
 

/kind feature
/priority important-soon
/assign