### PR TITLE
Fix test-e2e Makefile target by adding test parameter to kuttl tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -343,4 +343,4 @@ kind-deploy: kustomize $(KIND) ## Deploys the operator in the k8s kind cluster.
 
 test-e2e: export KUBECONFIG = ${PWD}/kubeconfig
 test-e2e: kind-create kustomize kind-deploy $(KUTTL) ## Run kuttl e2e tests in the k8s kind cluster.
-	$(KUTTL)
+	$(KUTTL) test


### PR DESCRIPTION
Apparently now **kuttl** tool used on test-e2e need to specify the `test`parameter, otherwise it doesnt do anything showing the `help` output.

/kind fix
/priority important-soon